### PR TITLE
Write UFO .glif note as CDATA (#15)

### DIFF
--- a/Lib/sfdLib/parser.py
+++ b/Lib/sfdLib/parser.py
@@ -5,6 +5,7 @@ import re
 
 from datetime import datetime
 from fontTools.misc.fixedTools import otRound
+from lxml.etree import CDATA
 import sfdutf7
 
 SFDReadUTF7 = lambda s, force_valid_xml=True: sfdutf7.decode(
@@ -738,7 +739,7 @@ class SFDParser:
                 pass  # XXX
             elif not self._minimal:
                 if key == "Comment":
-                    glyph.note = SFDReadUTF7(value)
+                    glyph.note = CDATA(SFDReadUTF7(value))
                 elif key == "Colour":
                     glyph.markColor = _parseColor(int(value, 16))
 


### PR DESCRIPTION
Allows round-tripping through FontForge.

Closes #15.

Cannot be merged until https://github.com/fonttools/fonttools/pull/2746/ lands in a release.